### PR TITLE
Performance improvements using spidev to update the 12.48inch e-Paper Module with Python

### DIFF
--- a/RaspberryPi/python/examples/epd_12in48_test.py
+++ b/RaspberryPi/python/examples/epd_12in48_test.py
@@ -1,25 +1,21 @@
 ﻿#!/usr/bin/python
 # -*- coding:utf-8 -*-
 
+import logging
+logging.basicConfig(level = logging.DEBUG)
+
+import time
 import sys
 import os
 picdir = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'pic')
 libdir = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), 'lib')
 if os.path.exists(libdir):
     sys.path.append(libdir)
-
-
 import epd12in48
-import time
 
 from PIL import Image
 from PIL import ImageDraw
 from PIL import ImageFont
-from PIL import ImageColor
-
-from PIL import Image
-
-import json
 
 print("12.48inch e-paper Demo...")
 
@@ -35,15 +31,15 @@ try:
     font10 = ImageFont.truetype(picdir+"/Font.ttc",60)
 
     print("drawing...")
-    draw.rectangle([(40,40),(440,440)],fill = "BLUE")
-    draw.rectangle([(43,43),(437,437)],fill = "WHITE")
-    draw.line([(40,40),(440,440)], fill = "BLUE",width = 3)
-    draw.line([(440,40),(40,440)], fill = "BLUE",width = 3)
-    draw.arc([50, 50, 430, 430], 0, 360, fill = "BLUE")
-    draw.text((60,500), u'微雪电子 ', font = font, fill = "BLUE")
-    draw.text((600, 90), 'Waveshare Electronic ', font = font10, fill = "BLUE")
-    draw.text((600, 170), '12.48 inch e-paper ', font = font10, fill = "BLUE")
-    draw.text((600, 250), 'Test Program ', font = font10, fill = "BLUE")
+    draw.rectangle([(40,40),(440,440)],fill = "Black")
+    draw.rectangle([(43,43),(437,437)],fill = "White")
+    draw.line([(40,40),(440,440)], fill = "Black",width = 3)
+    draw.line([(440,40),(40,440)], fill = "Black",width = 3)
+    draw.arc([50, 50, 430, 430], 0, 360, fill = "Black")
+    draw.text((60,500), u'微雪电子 ', font = font, fill = "Black")
+    draw.text((600, 90), 'Waveshare Electronic ', font = font10, fill = "Black")
+    draw.text((600, 170), '12.48 inch e-paper ', font = font10, fill = "Black")
+    draw.text((600, 250), 'Test Program ', font = font10, fill = "Black")
 
     image1=image1.rotate(0) 
     epd.display(image1)

--- a/RaspberryPi/python/lib/epd12in48.py
+++ b/RaspberryPi/python/lib/epd12in48.py
@@ -27,16 +27,27 @@
 # THE SOFTWARE.
 #
 import time
+import logging
+
 import epdconfig
+
+import PIL
+from PIL import Image
 
 EPD_WIDTH       = 1304
 EPD_HEIGHT      = 984
+
+EDP_M1S2_WIDTH  = 648
+EPD_M1S2_HEIGHT = 492
+
+EDP_M2S1_WIDTH  = 656
+EPD_M2S1_HEIGHT = 492
 
 class EPD(object):
     def __init__(self):
         self.width = EPD_WIDTH
         self.height = EPD_HEIGHT
-        
+
         self.EPD_M1_CS_PIN  = epdconfig.EPD_M1_CS_PIN
         self.EPD_S1_CS_PIN  = epdconfig.EPD_S1_CS_PIN
         self.EPD_M2_CS_PIN  = epdconfig.EPD_M2_CS_PIN
@@ -53,168 +64,180 @@ class EPD(object):
         self.EPD_M2_BUSY_PIN  = epdconfig.EPD_M2_BUSY_PIN
         self.EPD_S2_BUSY_PIN  = epdconfig.EPD_S2_BUSY_PIN
 
+
     def Init(self):
-        print("EPD init...")
-        epdconfig.module_init()
-        
-        epdconfig.digital_write(self.EPD_M1_CS_PIN, 1) 
-        epdconfig.digital_write(self.EPD_S1_CS_PIN, 1) 
-        epdconfig.digital_write(self.EPD_M2_CS_PIN, 1) 
-        epdconfig.digital_write(self.EPD_S2_CS_PIN, 1) 
-        self.Reset() 
+        if (epdconfig.module_init() != 0):
+            return -1
 
-        #panel setting
-        self.M1_SendCommand(0x00) 
-        self.M1_SendData(0x1f) 	#KW-3f   KWR-2F	BWROTP 0f	BWOTP 1f
-        self.S1_SendCommand(0x00) 
-        self.S1_SendData(0x1f) 
-        self.M2_SendCommand(0x00) 
-        self.M2_SendData(0x13) 
-        self.S2_SendCommand(0x00) 
-        self.S2_SendData(0x13) 
-
-        # booster soft start
-        self.M1_SendCommand(0x06) 
-        self.M1_SendData(0x17) 	#A
-        self.M1_SendData(0x17) 	#B
-        self.M1_SendData(0x39) 	#C
-        self.M1_SendData(0x17) 
-        self.M2_SendCommand(0x06) 
-        self.M2_SendData(0x17) 
-        self.M2_SendData(0x17) 
-        self.M2_SendData(0x39) 
-        self.M2_SendData(0x17) 
-
-        #resolution setting
-        self.M1_SendCommand(0x61) 
-        self.M1_SendData(0x02) 
-        self.M1_SendData(0x88) 	#source 648
-        self.M1_SendData(0x01) 	#gate 492
-        self.M1_SendData(0xEC) 
-        self.S1_SendCommand(0x61) 
-        self.S1_SendData(0x02) 
-        self.S1_SendData(0x90) 	#source 656
-        self.S1_SendData(0x01) 	#gate 492
-        self.S1_SendData(0xEC) 
-        self.M2_SendCommand(0x61) 
-        self.M2_SendData(0x02) 
-        self.M2_SendData(0x90) 	#source 656
-        self.M2_SendData(0x01) 	#gate 492
-        self.M2_SendData(0xEC) 
-        self.S2_SendCommand(0x61) 
-        self.S2_SendData(0x02) 
-        self.S2_SendData(0x88) 	#source 648
-        self.S2_SendData(0x01) 	#gate 492
-        self.S2_SendData(0xEC) 
-
-        self.M1S1M2S2_SendCommand(0x15) 	#DUSPI
-        self.M1S1M2S2_SendData(0x20) 
-
-        self.M1S1M2S2_SendCommand(0x50) 	#Vcom and data interval setting
-        self.M1S1M2S2_SendData(0x21)  #Border KW
-        self.M1S1M2S2_SendData(0x07) 
-
-        self.M1S1M2S2_SendCommand(0x60) #TCON
-        self.M1S1M2S2_SendData(0x22) 
-
-        self.M1S1M2S2_SendCommand(0xE3) 
-        self.M1S1M2S2_SendData(0x00) 
-
-        #temperature
-        temp =  self.M1_ReadTemperature() 
-
-        self.M1S1M2S2_SendCommand(0xe0) #Cascade setting
-        self.M1S1M2S2_SendData(0x03) 
-        self.M1S1M2S2_SendCommand(0xe5) #Force temperature
-        self.M1S1M2S2_SendData(temp)
-        
-    def display(self, Image):
-        start = time.clock()
-        buf = [0x00] * int(self.width * self.height / 8)
-        image_monocolor = Image.convert('1')
-        imwidth, imheight = image_monocolor.size 
-        pixels = image_monocolor.load()
-        temp=0;
-        for y in range(0, imheight):
-                for x in range(0, imwidth):
-                    # Set the bits for the column of pixels at the current position.
-                    if pixels[x, y] < 127:           # black
-                        buf[int((x + y*self.width)/8)] &= ~(0x80>>temp)
-                    else:                           # white
-                        buf[int((x + y*self.width)/8)] |= (0x80>>temp)
-                    temp=temp+1
-                    if(temp==8):
-                        temp=0
-
-        #M1 part 648*492    
-        self.M1_SendCommand(0x13)
-        for y in  range(492, 984):
-            for x in  range(0, 81):
-                    self.M1_SendData(buf[y*163 + x])
-
-        #S1 part 656*492
-        self.S1_SendCommand(0x13)
-        for y in  range(492, 984):
-            for x in  range(81, 163):
-                self.S1_SendData(buf[y*163 + x])
-
-        #M2 part 656*492
-        self.M2_SendCommand(0x13)
-        for y in  range(0, 492):
-            for x in  range(81, 163):
-                self.M2_SendData(buf[y*163 + x])
-
-        #S2 part 648*492
-        self.S2_SendCommand(0x13)
-        for y in  range(0, 492):
-            for x in  range(0, 81):
-                self.S2_SendData(buf[y*163 + x])
-                
-        end = time.clock()
-        print("use time:%f"%(end - start))
-        self.TurnOnDisplay()
-
-    def clear(self):
-        """Clear contents of image buffer"""
-        start = time.clock()
-        self.M1_SendCommand(0x13)
-        for y in  range(492, 984):
-            for x in  range(0, 81):
-                self.M1_SendData(0xff)
-
-        self.S1_SendCommand(0x13)
-        for y in  range(492, 984):
-            for x in  range(81, 163):
-                self.S1_SendData(0xff)
-    
-        self.M2_SendCommand(0x13)
-        for y in  range(0, 492):
-            for x in  range(81, 163):
-                self.M2_SendData(0xff)
-
-        self.S2_SendCommand(0x13)
-        for y in  range(0, 492):
-            for x in  range(0, 81):
-                self.S2_SendData(0xff)
-        end = time.clock()
-        print("use time:%f"%(end - start))
-        self.TurnOnDisplay()
-        
-    """   M1S1M2S2 Write register address and data     """
-    def M1S1M2S2_SendCommand(self, cmd):
-        epdconfig.digital_write(self.EPD_M1S1_DC_PIN, 0)
-        epdconfig.digital_write(self.EPD_M2S2_DC_PIN, 0)
-        
-        epdconfig.digital_write(self.EPD_M1_CS_PIN, 0)
-        epdconfig.digital_write(self.EPD_S1_CS_PIN, 0)
-        epdconfig.digital_write(self.EPD_M2_CS_PIN, 0)
-        epdconfig.digital_write(self.EPD_S2_CS_PIN, 0)
-        epdconfig.spi_writebyte(cmd) 
         epdconfig.digital_write(self.EPD_M1_CS_PIN, 1)
         epdconfig.digital_write(self.EPD_S1_CS_PIN, 1)
         epdconfig.digital_write(self.EPD_M2_CS_PIN, 1)
         epdconfig.digital_write(self.EPD_S2_CS_PIN, 1)
-    
+
+        self.Reset()
+
+        # panel setting
+        self.M1_SendCommand(0x00)
+        self.M1_SendData(0x1f)  #KW-3f   KWR-2F BWROTP 0f   BWOTP 1f
+        self.S1_SendCommand(0x00)
+        self.S1_SendData(0x1f)
+        self.M2_SendCommand(0x00)
+        self.M2_SendData(0x13)
+        self.S2_SendCommand(0x00)
+        self.S2_SendData(0x13)
+
+        # booster soft start
+        self.M1_SendCommand(0x06)
+        # A B C
+        self.M1_SendDataBulk([0x17, 0x17, 0x39, 0x17])
+        self.M2_SendCommand(0x06)
+        # A B C
+        self.M2_SendDataBulk([0x17, 0x17, 0x39, 0x17])
+
+        #resolution setting
+        self.M1_SendCommand(0x61)
+        # Source 648, Gate 492
+        self.M1_SendDataBulk([0x02, 0x88, 0x01, 0xEC])
+
+        self.S1_SendCommand(0x61)
+        # Source 656, Gate 492
+        self.S1_SendDataBulk([0x02, 0x90, 0x01, 0xEC])
+
+        self.M2_SendCommand(0x61)
+        # Source 656, Gate 492
+        self.M2_SendDataBulk([0x02, 0x90, 0x01, 0xEC])
+
+        self.S2_SendCommand(0x61)
+        # Source 648, Gate 492
+        self.S2_SendDataBulk([0x02, 0x88, 0x01, 0xEC])
+
+        self.M1S1M2S2_SendCommand(0x15) # DUSPI
+        self.M1S1M2S2_SendData(0x20)
+
+        self.M1S1M2S2_SendCommand(0x50) # Vcom and data interval setting
+        self.M1S1M2S2_SendData(0x21)    # Border KW
+        self.M1S1M2S2_SendData(0x07)
+
+        self.M1S1M2S2_SendCommand(0x60) # TCON
+        self.M1S1M2S2_SendData(0x22)
+
+        self.M1S1M2S2_SendCommand(0xE3)
+        self.M1S1M2S2_SendData(0x00)
+
+        # temperature
+        # Hardcoded for now, SPI reads are not working right
+        temp = 19 #self.M1_ReadTemperature()
+
+        self.M1S1M2S2_SendCommand(0xe0) #Cascade setting
+        self.M1S1M2S2_SendData(0x03)
+        self.M1S1M2S2_SendCommand(0xe5) #Force temperature
+        self.M1S1M2S2_SendData(temp)
+
+
+    def display(self, image):
+        start = time.perf_counter()
+
+        # Check if we need to rotate the image
+         imwidth, imheight = image.size
+         if(imwidth == self.width and imheight == self.height):
+             image_temp = image
+         elif(imwidth == self.height and imheight == self.width):
+             image_temp = image.rotate(90, expand=True)
+         else:
+             logging.warning("Invalid image dimensions: %d x %d, expected %d x %d" % (imwidth, imheight, self.width, self.height))
+
+        image_monocolor = image_temp.convert('1')
+        buf = bytearray(image_monocolor.tobytes('raw'))
+
+        end = time.perf_counter()
+        logging.debug("format pixels time:%f" % (end - start))
+        start = time.perf_counter()
+
+        buf_M2S1 = [0xFF] * int((EDP_M2S1_WIDTH * EPD_M2S1_HEIGHT)/8)
+        buf_M1S2 = [0xFF] * int((EDP_M1S2_WIDTH * EPD_M1S2_HEIGHT)/8)
+
+        #M1 part 648*492
+        idx = 0
+        for y in  range(492, 984):
+            for x in  range(0, 81):
+                buf_M1S2[idx] = buf[y*163 + x]
+                idx += 1
+        self.M1_SendCommand(0x13)
+        self.M1_SendDataBulk(buf_M1S2)
+
+        #S1 part 656*492
+        idx = 0
+        for y in  range(492, 984):
+            for x in  range(81, 163):
+                buf_M2S1[idx] = buf[y*163 + x]
+                idx += 1
+        self.S1_SendCommand(0x13)
+        self.S1_SendDataBulk(buf_M2S1)
+
+        #M2 part 656*492
+        idx = 0
+        for y in  range(0, 492):
+            for x in  range(81, 163):
+                buf_M2S1[idx] = buf[y*163 + x]
+                idx += 1
+        self.M2_SendCommand(0x13)
+        self.M2_SendDataBulk(buf_M2S1)
+
+
+        #S2 part 648*492
+        idx = 0
+        for y in  range(0, 492):
+            for x in  range(0, 81):
+                buf_M1S2[idx] = buf[y*163 + x]
+                idx += 1
+        self.S2_SendCommand(0x13)
+        self.S2_SendDataBulk(buf_M1S2)
+
+        end = time.perf_counter()
+        logging.debug("send pixel time: %f" % (end - start))
+
+        self.TurnOnDisplay()
+
+
+    def clear(self):
+        """Clear contents of image buffer"""
+        start = time.perf_counter()
+
+        buf_M2S1 = [0xFF] * int((EDP_M2S1_WIDTH * EPD_M2S1_HEIGHT)/8)
+        buf_M1S2 = [0xFF] * int((EDP_M1S2_WIDTH * EPD_M1S2_HEIGHT)/8)
+
+        self.M1_SendCommand(0x13)
+        self.M1_SendDataBulk(buf_M1S2)
+
+        self.S1_SendCommand(0x13)
+        self.S1_SendDataBulk(buf_M2S1)
+
+        self.M2_SendCommand(0x13)
+        self.M2_SendDataBulk(buf_M2S1)
+
+        self.S2_SendCommand(0x13)
+        self.S2_SendDataBulk(buf_M1S2)
+
+        end = time.perf_counter()
+        logging.debug("send clear pixel time: %f" % (end - start))
+
+        self.TurnOnDisplay()
+
+    """   M1S1M2S2 Write register address and data     """
+    def M1S1M2S2_SendCommand(self, cmd):
+        epdconfig.digital_write(self.EPD_M1S1_DC_PIN, 0)
+        epdconfig.digital_write(self.EPD_M2S2_DC_PIN, 0)
+
+        epdconfig.digital_write(self.EPD_M1_CS_PIN, 0)
+        epdconfig.digital_write(self.EPD_S1_CS_PIN, 0)
+        epdconfig.digital_write(self.EPD_M2_CS_PIN, 0)
+        epdconfig.digital_write(self.EPD_S2_CS_PIN, 0)
+        epdconfig.spi_writebyte([cmd])
+        epdconfig.digital_write(self.EPD_M1_CS_PIN, 1)
+        epdconfig.digital_write(self.EPD_S1_CS_PIN, 1)
+        epdconfig.digital_write(self.EPD_M2_CS_PIN, 1)
+        epdconfig.digital_write(self.EPD_S2_CS_PIN, 1)
+
     def M1S1M2S2_SendData(self, val):
         epdconfig.digital_write(self.EPD_M1S1_DC_PIN, 1)
         epdconfig.digital_write(self.EPD_M2S2_DC_PIN, 1)
@@ -223,7 +246,7 @@ class EPD(object):
         epdconfig.digital_write(self.EPD_S1_CS_PIN, 0)
         epdconfig.digital_write(self.EPD_M2_CS_PIN, 0)
         epdconfig.digital_write(self.EPD_S2_CS_PIN, 0)
-        epdconfig.spi_writebyte(val) 
+        epdconfig.spi_writebyte([val])
         epdconfig.digital_write(self.EPD_M1_CS_PIN, 1)
         epdconfig.digital_write(self.EPD_S1_CS_PIN, 1)
         epdconfig.digital_write(self.EPD_M2_CS_PIN, 1)
@@ -235,164 +258,194 @@ class EPD(object):
         epdconfig.digital_write(self.EPD_M2S2_DC_PIN, 0)
         epdconfig.digital_write(self.EPD_M1_CS_PIN, 0)
         epdconfig.digital_write(self.EPD_M2_CS_PIN, 0)
-        epdconfig.spi_writebyte(cmd) 
+        epdconfig.spi_writebyte([cmd])
         epdconfig.digital_write(self.EPD_M1_CS_PIN, 1)
         epdconfig.digital_write(self.EPD_M2_CS_PIN, 1)
-        
-    def M1S1M2S2_Senddata(self, val): 
+
+    def M1S1M2S2_Senddata(self, val):
         epdconfig.digital_write(self.EPD_M1S1_DC_PIN, 1)
         epdconfig.digital_write(self.EPD_M2S2_DC_PIN, 1)
         epdconfig.digital_write(self.EPD_M1_CS_PIN, 0)
         epdconfig.digital_write(self.EPD_M2_CS_PIN, 0)
-        epdconfig.spi_writebyte(val) 
+        epdconfig.spi_writebyte([val])
         epdconfig.digital_write(self.EPD_M1_CS_PIN, 1)
-        epdconfig.digital_write(self.EPD_M2_CS_PIN, 1)   
-          
+        epdconfig.digital_write(self.EPD_M2_CS_PIN, 1)
+
+
     """   S2 Write register address and data     """
     def S2_SendCommand(self, cmd):
         epdconfig.digital_write(self.EPD_M2S2_DC_PIN, 0)
         epdconfig.digital_write(self.EPD_S2_CS_PIN, 0)
-        epdconfig.spi_writebyte(cmd)
+        epdconfig.spi_writebyte([cmd])
         epdconfig.digital_write(self.EPD_S2_CS_PIN, 1)
-
 
     def S2_SendData(self, val):
         epdconfig.digital_write(self.EPD_M2S2_DC_PIN, 1)
         epdconfig.digital_write(self.EPD_S2_CS_PIN, 0)
-        epdconfig.spi_writebyte(val)
+        epdconfig.spi_writebyte([val])
         epdconfig.digital_write(self.EPD_S2_CS_PIN, 1)
-        
+
+    def S2_SendDataBulk(self, val):
+        epdconfig.digital_write(self.EPD_M2S2_DC_PIN, 1)
+        epdconfig.digital_write(self.EPD_S2_CS_PIN, 0)
+        epdconfig.spi_writebytes(val)
+        epdconfig.digital_write(self.EPD_S2_CS_PIN, 1)
+
+
     """   M2 Write register address and data     """
     def M2_SendCommand(self, cmd):
         epdconfig.digital_write(self.EPD_M2S2_DC_PIN, 0)
         epdconfig.digital_write(self.EPD_M2_CS_PIN, 0)
-        epdconfig.spi_writebyte(cmd) 
+        epdconfig.spi_writebyte([cmd])
         epdconfig.digital_write(self.EPD_M2_CS_PIN, 1)
 
     def M2_SendData(self, val):
         epdconfig.digital_write(self.EPD_M2S2_DC_PIN, 1)
         epdconfig.digital_write(self.EPD_M2_CS_PIN, 0)
-        epdconfig.spi_writebyte(val) 
+        epdconfig.spi_writebyte([val])
         epdconfig.digital_write(self.EPD_M2_CS_PIN, 1)
+
+    def M2_SendDataBulk(self, val):
+        epdconfig.digital_write(self.EPD_M2S2_DC_PIN, 1)
+        epdconfig.digital_write(self.EPD_M2_CS_PIN, 0)
+        epdconfig.spi_writebytes(val)
+        epdconfig.digital_write(self.EPD_M2_CS_PIN, 1)
+
 
     """   S1 Write register address and data     """
     def S1_SendCommand(self, cmd):
         epdconfig.digital_write(self.EPD_M1S1_DC_PIN, 0)
         epdconfig.digital_write(self.EPD_S1_CS_PIN, 0)
-        epdconfig.spi_writebyte(cmd)
+        epdconfig.spi_writebyte([cmd])
         epdconfig.digital_write(self.EPD_S1_CS_PIN, 1)
 
     def S1_SendData(self, val):
         epdconfig.digital_write(self.EPD_M1S1_DC_PIN, 1)
         epdconfig.digital_write(self.EPD_S1_CS_PIN, 0)
-        epdconfig.spi_writebyte(val)
+        epdconfig.spi_writebyte([val])
         epdconfig.digital_write(self.EPD_S1_CS_PIN, 1)
-        
+
+    def S1_SendDataBulk(self, val):
+        epdconfig.digital_write(self.EPD_M1S1_DC_PIN, 1)
+        epdconfig.digital_write(self.EPD_S1_CS_PIN, 0)
+        epdconfig.spi_writebytes(val)
+        epdconfig.digital_write(self.EPD_S1_CS_PIN, 1)
+
+
     """   M1 Write register address and data     """
     def M1_SendCommand(self, cmd):
         epdconfig.digital_write(self.EPD_M1S1_DC_PIN, 0)
         epdconfig.digital_write(self.EPD_M1_CS_PIN, 0)
-        epdconfig.spi_writebyte(cmd)
+        epdconfig.spi_writebyte([cmd])
         epdconfig.digital_write(self.EPD_M1_CS_PIN, 1)
 
     def M1_SendData(self, val):
         epdconfig.digital_write(self.EPD_M1S1_DC_PIN, 1)
         epdconfig.digital_write(self.EPD_M1_CS_PIN, 0)
-        epdconfig.spi_writebyte(val)
+        epdconfig.spi_writebyte([val])
         epdconfig.digital_write(self.EPD_M1_CS_PIN, 1)
 
-    def Reset(self):
-        epdconfig.digital_write(self.EPD_M1S1_RST_PIN, 1) 
-        epdconfig.digital_write(self.EPD_M2S2_RST_PIN, 1) 
-        time.sleep(0.2) 
-        epdconfig.digital_write(self.EPD_M1S1_RST_PIN, 0) 
-        epdconfig.digital_write(self.EPD_M2S2_RST_PIN, 0) 
-        time.sleep(0.02) 
-        epdconfig.digital_write(self.EPD_M1S1_RST_PIN, 1) 
-        epdconfig.digital_write(self.EPD_M2S2_RST_PIN, 1) 
-        time.sleep(0.2) 
-    
-    def EPD_Sleep(self):
-        self.M1S1M2S2_SendCommand(0X02)   	
-        time.sleep(0.3) 
+    def M1_SendDataBulk(self, val):
+        epdconfig.digital_write(self.EPD_M1S1_DC_PIN, 1)
+        epdconfig.digital_write(self.EPD_M1_CS_PIN, 0)
+        epdconfig.spi_writebytes(val)
+        epdconfig.digital_write(self.EPD_M1_CS_PIN, 1)
 
-        self.M1S1M2S2_SendCommand(0X07)   	
-        self.M1S1M2S2_SendData(0xA5) 
-        time.sleep(0.3) 
-        print("module_exit")
+
+    def Reset(self):
+        logging.debug("epd12in48 Reset")
+        epdconfig.digital_write(self.EPD_M1S1_RST_PIN, 1)
+        epdconfig.digital_write(self.EPD_M2S2_RST_PIN, 1)
+        time.sleep(0.2)
+        epdconfig.digital_write(self.EPD_M1S1_RST_PIN, 0)
+        epdconfig.digital_write(self.EPD_M2S2_RST_PIN, 0)
+        time.sleep(0.001)
+        epdconfig.digital_write(self.EPD_M1S1_RST_PIN, 1)
+        epdconfig.digital_write(self.EPD_M2S2_RST_PIN, 1)
+        time.sleep(0.2)
+        logging.debug("epd12in48 Reset done")
+
+
+    def EPD_Sleep(self):
+        logging.debug("epd12in48 EPD_Sleep")
+        self.M1S1M2S2_SendCommand(0X02)
+        time.sleep(0.3)
+        self.M1S1M2S2_SendCommand(0X07)
+        self.M1S1M2S2_SendData(0xA5)
+        time.sleep(0.3)
         epdconfig.module_exit()
-        
-        
+
+
     def TurnOnDisplay(self):
-        self.M1M2_SendCommand(0x04)  
-        time.sleep(0.3) 
-        self.M1S1M2S2_SendCommand(0x12) 
-        self.M1_ReadBusy()
+        start = time.perf_counter()
+        self.M1M2_SendCommand(0x04)
+        time.sleep(0.3)
+        self.M1S1M2S2_SendCommand(0x12)
         self.S1_ReadBusy()
         self.M2_ReadBusy()
         self.S2_ReadBusy()
-    
+        self.M1_ReadBusy()
+        end = time.perf_counter()
+        logging.debug("display draw time: %f" % (end - start))
+
+
     #Busy
     def M1_ReadBusy(self):
-        self.M1_SendCommand(0x71) 
-        busy = epdconfig.digital_read(self.EPD_M1_BUSY_PIN) 
-        busy = not(busy & 0x01) 
-        print("M1_ReadBusy")
+        self.M1_SendCommand(0x71)
+        busy = epdconfig.digital_read(self.EPD_M1_BUSY_PIN)
+        busy = not(busy & 0x01)
+        logging.debug("M1_ReadBusy")
         while(busy):
-            self.M1_SendCommand(0x71) 
-            busy = epdconfig.digital_read(self.EPD_M1_BUSY_PIN) 
-            busy = not(busy & 0x01) 
-        time.sleep(0.2)
-        
-    def M2_ReadBusy(self):
-        self.M2_SendCommand(0x71) 
-        busy = epdconfig.digital_read(self.EPD_M2_BUSY_PIN) 
-        busy = not(busy & 0x01) 
-        print("M2_ReadBusy")
-        while(busy):
-            self.M2_SendCommand(0x71) 
-            busy = epdconfig.digital_read(self.EPD_M2_BUSY_PIN) 
-            busy =not(busy & 0x01) 
-        time.sleep(0.2)   
-        
-    def S1_ReadBusy(self):
-        self.S1_SendCommand(0x71) 
-        busy = epdconfig.digital_read(self.EPD_S1_BUSY_PIN) 
-        busy = not(busy & 0x01) 
-        print("s1_ReadBusy")
-        while(busy):
-            self.S1_SendCommand(0x71) 
-            busy = epdconfig.digital_read(self.EPD_S1_BUSY_PIN) 
-            busy = not(busy & 0x01) 
-        time.sleep(0.2)   
-        
-    def S2_ReadBusy(self):
-        self.S2_SendCommand(0x71) 
-        busy = epdconfig.digital_read(self.EPD_S2_BUSY_PIN) 
-        busy = not(busy & 0x01) 
-        print("S2_ReadBusy")
-        while(busy):
-            self.S2_SendCommand(0x71) 
-            busy = epdconfig.digital_read(self.EPD_S2_BUSY_PIN) 
-            busy = not(busy & 0x01) 
-        time.sleep(0.2)            
-        
-    def M1_ReadTemperature(self):
-        self.M1_SendCommand(0x40) 
-        self.M1_ReadBusy() 
-        time.sleep(0.3) 
+            self.M1_SendCommand(0x71)
+            busy = epdconfig.digital_read(self.EPD_M1_BUSY_PIN)
+            busy = not(busy & 0x01)
 
-        epdconfig.digital_write(self.EPD_M1_CS_PIN, 0) 
-        epdconfig.digital_write(self.EPD_S1_CS_PIN, 1) 
-        epdconfig.digital_write(self.EPD_M2_CS_PIN, 1) 
-        epdconfig.digital_write(self.EPD_S2_CS_PIN, 1) 
-        
-        epdconfig.digital_write(self.EPD_M1S1_DC_PIN, 1) 
-        time.sleep(0.01) 
-        
-        # temp = epdconfig.spi_readbyte(0x00)
-        temp = 19
-        print("Read Temperature Reg:%d"%temp)
-        epdconfig.digital_write(self.EPD_M1_CS_PIN, 1) 
-        # temp =0x29
-        return temp 
+    def M2_ReadBusy(self):
+        self.M2_SendCommand(0x71)
+        busy = epdconfig.digital_read(self.EPD_M2_BUSY_PIN)
+        busy = not(busy & 0x01)
+        logging.debug("M2_ReadBusy")
+        while(busy):
+            self.M2_SendCommand(0x71)
+            busy = epdconfig.digital_read(self.EPD_M2_BUSY_PIN)
+            busy =not(busy & 0x01)
+
+    def S1_ReadBusy(self):
+        self.S1_SendCommand(0x71)
+        busy = epdconfig.digital_read(self.EPD_S1_BUSY_PIN)
+        busy = not(busy & 0x01)
+        logging.debug("s1_ReadBusy")
+        while(busy):
+            self.S1_SendCommand(0x71)
+            busy = epdconfig.digital_read(self.EPD_S1_BUSY_PIN)
+            busy = not(busy & 0x01)
+
+    def S2_ReadBusy(self):
+        self.S2_SendCommand(0x71)
+        busy = epdconfig.digital_read(self.EPD_S2_BUSY_PIN)
+        busy = not(busy & 0x01)
+        logging.debug("S2_ReadBusy")
+        while(busy):
+            self.S2_SendCommand(0x71)
+            busy = epdconfig.digital_read(self.EPD_S2_BUSY_PIN)
+            busy = not(busy & 0x01)
+
+
+    def M1_ReadTemperature(self):
+        self.M1_SendCommand(0x43)
+        self.M1_ReadBusy()
+        time.sleep(0.3)
+
+        epdconfig.digital_write(self.EPD_M1_CS_PIN, 0)
+        epdconfig.digital_write(self.EPD_S1_CS_PIN, 1)
+        epdconfig.digital_write(self.EPD_M2_CS_PIN, 1)
+        epdconfig.digital_write(self.EPD_S2_CS_PIN, 1)
+
+        epdconfig.digital_write(self.EPD_M1S1_DC_PIN, 1)
+        time.sleep(0.1)
+
+        temp = epdconfig.spi_readbyte()
+        logging.debug("Read Temperature Reg: %d" % temp)
+        epdconfig.digital_write(self.EPD_M1_CS_PIN, 1)
+        return temp
+

--- a/RaspberryPi/python/lib/epd12in48.py
+++ b/RaspberryPi/python/lib/epd12in48.py
@@ -138,13 +138,13 @@ class EPD(object):
         start = time.perf_counter()
 
         # Check if we need to rotate the image
-         imwidth, imheight = image.size
-         if(imwidth == self.width and imheight == self.height):
-             image_temp = image
-         elif(imwidth == self.height and imheight == self.width):
-             image_temp = image.rotate(90, expand=True)
-         else:
-             logging.warning("Invalid image dimensions: %d x %d, expected %d x %d" % (imwidth, imheight, self.width, self.height))
+        imwidth, imheight = image.size
+        if(imwidth == self.width and imheight == self.height):
+            image_temp = image
+        elif(imwidth == self.height and imheight == self.width):
+            image_temp = image.rotate(90, expand=True)
+        else:
+            logging.warning("Invalid image dimensions: %d x %d, expected %d x %d" % (imwidth, imheight, self.width, self.height))
 
         image_monocolor = image_temp.convert('1')
         buf = bytearray(image_monocolor.tobytes('raw'))

--- a/RaspberryPi/python/lib/epd12in48.py
+++ b/RaspberryPi/python/lib/epd12in48.py
@@ -399,6 +399,7 @@ class EPD(object):
             self.M1_SendCommand(0x71)
             busy = epdconfig.digital_read(self.EPD_M1_BUSY_PIN)
             busy = not(busy & 0x01)
+        time.sleep(0.2)
 
     def M2_ReadBusy(self):
         self.M2_SendCommand(0x71)
@@ -409,6 +410,7 @@ class EPD(object):
             self.M2_SendCommand(0x71)
             busy = epdconfig.digital_read(self.EPD_M2_BUSY_PIN)
             busy =not(busy & 0x01)
+        time.sleep(0.2)
 
     def S1_ReadBusy(self):
         self.S1_SendCommand(0x71)
@@ -419,6 +421,7 @@ class EPD(object):
             self.S1_SendCommand(0x71)
             busy = epdconfig.digital_read(self.EPD_S1_BUSY_PIN)
             busy = not(busy & 0x01)
+        time.sleep(0.2)
 
     def S2_ReadBusy(self):
         self.S2_SendCommand(0x71)
@@ -429,6 +432,7 @@ class EPD(object):
             self.S2_SendCommand(0x71)
             busy = epdconfig.digital_read(self.EPD_S2_BUSY_PIN)
             busy = not(busy & 0x01)
+        time.sleep(0.2)
 
 
     def M1_ReadTemperature(self):

--- a/RaspberryPi/python/lib/epdconfig.py
+++ b/RaspberryPi/python/lib/epdconfig.py
@@ -26,123 +26,121 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #
-import RPi.GPIO as GPIO
 import time
 import os
 import logging
 import sys
 
-from ctypes import *
 
-EPD_SCK_PIN   =11
-EPD_MOSI_PIN  =10
+class RaspberryPi:
 
-EPD_M1_CS_PIN  =8
-EPD_S1_CS_PIN  =7
-EPD_M2_CS_PIN  =17
-EPD_S2_CS_PIN  =18
+    # Pin definitions
+    EPD_M1_CS_PIN    = 8
+    EPD_S1_CS_PIN    = 7
+    EPD_M2_CS_PIN    = 17
+    EPD_S2_CS_PIN    = 18
 
-EPD_M1S1_DC_PIN  =13
-EPD_M2S2_DC_PIN  =22
+    EPD_M1S1_DC_PIN  = 13
+    EPD_M2S2_DC_PIN  = 22
 
-EPD_M1S1_RST_PIN =6
-EPD_M2S2_RST_PIN =23
+    EPD_M1S1_RST_PIN = 6
+    EPD_M2S2_RST_PIN = 23
 
-EPD_M1_BUSY_PIN  =5
-EPD_S1_BUSY_PIN  =19
-EPD_M2_BUSY_PIN  =27
-EPD_S2_BUSY_PIN  =24
+    EPD_M1_BUSY_PIN  = 5
+    EPD_S1_BUSY_PIN  = 19
+    EPD_M2_BUSY_PIN  = 27
+    EPD_S2_BUSY_PIN  = 24
 
-find_dirs = [
-    os.path.dirname(os.path.realpath(__file__)),
-    '/usr/local/lib',
-    '/usr/lib',
-]
-spi = None
-for find_dir in find_dirs:
-    so_filename = os.path.join(find_dir, 'DEV_Config.so')
-    if os.path.exists(so_filename):
-        spi = CDLL(so_filename)
-        break
-if spi is None:
-    RuntimeError('Cannot find DEV_Config.so')
+    def __init__(self):
+        import spidev
+        import RPi.GPIO
 
+        logging.debug("Using RaspberryPi implementation.")
 
-def digital_write(pin, value):
-    GPIO.output(pin, value)
+        self.GPIO = RPi.GPIO
+        self.SPI = spidev.SpiDev()
 
-def digital_read(pin):
-    return GPIO.input(pin)
+    def digital_write(self, pin, value):
+        self.GPIO.output(pin, value)
 
-def spi_writebyte(value): 
-    spi.DEV_SPI_WriteByte(value)
- 
-def delay_ms(delaytime):
-    time.sleep(delaytime / 1000.0)
-        
-def module_init():
-    GPIO.setmode(GPIO.BCM)
-    GPIO.setwarnings(False)
-    GPIO.setup(EPD_SCK_PIN, GPIO.OUT)    
-    GPIO.setup(EPD_MOSI_PIN, GPIO.OUT)
-    
-    logging.debug("python call wiringPi Lib")
-    
-    GPIO.setup(EPD_M2S2_RST_PIN, GPIO.OUT)    
-    GPIO.setup(EPD_M1S1_RST_PIN, GPIO.OUT)
-    GPIO.setup(EPD_M2S2_DC_PIN, GPIO.OUT)
-    GPIO.setup(EPD_M1S1_DC_PIN, GPIO.OUT)
-    GPIO.setup(EPD_S1_CS_PIN, GPIO.OUT)
-    GPIO.setup(EPD_S2_CS_PIN, GPIO.OUT)
-    GPIO.setup(EPD_M1_CS_PIN, GPIO.OUT)
-    GPIO.setup(EPD_M2_CS_PIN, GPIO.OUT)
+    def digital_read(self, pin):
+        return self.GPIO.input(pin)
 
-    GPIO.setup(EPD_S1_BUSY_PIN, GPIO.IN)
-    GPIO.setup(EPD_S2_BUSY_PIN, GPIO.IN)
-    GPIO.setup(EPD_M1_BUSY_PIN, GPIO.IN)
-    GPIO.setup(EPD_M2_BUSY_PIN, GPIO.IN)
-    
-    digital_write(EPD_M1_CS_PIN, 1)
-    digital_write(EPD_S1_CS_PIN, 1)
-    digital_write(EPD_M2_CS_PIN, 1)
-    digital_write(EPD_S2_CS_PIN, 1)
-    
-    digital_write(EPD_M2S2_RST_PIN, 0)
-    digital_write(EPD_M1S1_RST_PIN, 0)
-    digital_write(EPD_M2S2_DC_PIN, 1)
-    digital_write(EPD_M1S1_DC_PIN, 1)
+    def spi_writebyte(self, data):
+        self.SPI.writebytes(data)
 
-    spi.DEV_ModuleInit()
+    def spi_writebytes(self, data):
+        self.SPI.writebytes2(data)
 
-def module_exit():
-    digital_write(EPD_M2S2_RST_PIN, 0)
-    digital_write(EPD_M1S1_RST_PIN, 0)
-    digital_write(EPD_M2S2_DC_PIN, 0)
-    digital_write(EPD_M1S1_DC_PIN, 0)
-    digital_write(EPD_S1_CS_PIN, 1)
-    digital_write(EPD_S2_CS_PIN, 1)
-    digital_write(EPD_M1_CS_PIN, 1)
-    digital_write(EPD_M2_CS_PIN, 1)
+    def spi_readbyte(self):
+        bytes = self.SPI.readbytes(2)
+        logging.debug("spi_readbyte: %s" % (str(bytes)))
+        return bytes[0]
 
-def spi_readbyte(Reg):
-    GPIO.setup(EPD_MOSI_PIN, GPIO.IN)
-    j=0
-    # time.sleep(0.01)
-    for i in range(0, 8):
-        GPIO.output(EPD_SCK_PIN, GPIO.LOW) 
-        # time.sleep(0.01) 
-        j = j << 1 
-        if(GPIO.input(EPD_MOSI_PIN) == GPIO.HIGH):
-            j |= 0x01
-        else:
-            j &= 0xfe 
-        # time.sleep(0.01)
-        GPIO.output(EPD_SCK_PIN, GPIO.HIGH) 
-        # time.sleep(0.01)  
-    GPIO.setup(EPD_MOSI_PIN, GPIO.OUT)
-    return j 
-    
-    def delay_ms(delaytime):
+    def delay_ms(self, delaytime):
         time.sleep(delaytime / 1000.0)
 
+    def module_init(self):
+        self.GPIO.setmode(self.GPIO.BCM)
+        self.GPIO.setwarnings(False)
+
+        logging.debug("python call wiringPi Lib")
+
+        self.GPIO.setup(self.EPD_M2S2_RST_PIN, self.GPIO.OUT)
+        self.GPIO.setup(self.EPD_M1S1_RST_PIN, self.GPIO.OUT)
+        self.GPIO.setup(self.EPD_M2S2_DC_PIN, self.GPIO.OUT)
+        self.GPIO.setup(self.EPD_M1S1_DC_PIN, self.GPIO.OUT)
+        self.GPIO.setup(self.EPD_S1_CS_PIN, self.GPIO.OUT)
+        self.GPIO.setup(self.EPD_S2_CS_PIN, self.GPIO.OUT)
+        self.GPIO.setup(self.EPD_M1_CS_PIN, self.GPIO.OUT)
+        self.GPIO.setup(self.EPD_M2_CS_PIN, self.GPIO.OUT)
+
+        self.GPIO.setup(self.EPD_S1_BUSY_PIN, self.GPIO.IN)
+        self.GPIO.setup(self.EPD_S2_BUSY_PIN, self.GPIO.IN)
+        self.GPIO.setup(self.EPD_M1_BUSY_PIN, self.GPIO.IN)
+        self.GPIO.setup(self.EPD_M2_BUSY_PIN, self.GPIO.IN)
+
+        # SPI device, bus = 0, device = 0
+        self.SPI.open(0, 0)
+        self.SPI.max_speed_hz = 4000000
+        self.SPI.mode = 0b00
+
+        # Tell spidev we do not want the kernel SPI driver
+        # using the CE01 line
+        self.SPI.no_cs = True
+
+        self.digital_write(self.EPD_M1_CS_PIN, 1)
+        self.digital_write(self.EPD_S1_CS_PIN, 1)
+        self.digital_write(self.EPD_M2_CS_PIN, 1)
+        self.digital_write(self.EPD_S2_CS_PIN, 1)
+
+        self.digital_write(self.EPD_M2S2_RST_PIN, 0)
+        self.digital_write(self.EPD_M1S1_RST_PIN, 0)
+        self.digital_write(self.EPD_M2S2_DC_PIN, 1)
+        self.digital_write(self.EPD_M1S1_DC_PIN, 1)
+
+        return 0
+
+    def module_exit(self):
+        self.SPI.close()
+        logging.debug("close 5V, Module enters 0 power consumption ...")
+
+        self.GPIO.output(self.EPD_M1S1_RST_PIN, 0)
+        self.GPIO.output(self.EPD_M2S2_RST_PIN, 0)
+        self.GPIO.output(self.EPD_M2S2_DC_PIN, 0)
+        self.GPIO.output(self.EPD_M1S1_DC_PIN, 0)
+
+        self.digital_write(self.EPD_S1_CS_PIN, 1)
+        self.digital_write(self.EPD_S2_CS_PIN, 1)
+        self.digital_write(self.EPD_M1_CS_PIN, 1)
+        self.digital_write(self.EPD_M2_CS_PIN, 1)
+
+        self.GPIO.cleanup()
+
   
+
+if os.path.exists('/sys/bus/platform/drivers/gpiomem-bcm2835'):
+    implementation = RaspberryPi()
+
+for func in [x for x in dir(implementation) if not x.startswith('_')]:
+    setattr(sys.modules[__name__], func, getattr(implementation, func))


### PR DESCRIPTION
These changes significantly reduce the time required to process the image to display and update the panel.  This is particularly true on less powerful hardware, like the Raspberry Pi Zero W.  Highlights of the changes are:

- Use the Python `spidev` library to access SPI, instead of a C "bit banged" implementation.
- Transfer pixel data as a bulk transfer, using the `SPI.writebytes2()` function.
- Access the bytes of the image using `tobytes('raw')`.
- Turn on DEBUG logging by default and print the times to transfer pixel data and update the panel.
- Clean up some whitespace.
- Lay the groundwork for a Jetson implementation. 

Using the existing demo code as an example running in the following environment, the runtime is greatly reduced.

Hardware:
`Raspberry Pi Zero W`
OS:
`Raspbian GNU/Linux 10 (buster)`
Software:
`Python 3.7.3`


Original:
```
python3 epd_12in48_test.py
real	2m41.054s
user	2m29.895s
sys	0m0.220s
```

Using branch `epd12in48_spidev_python`:
```
python3 epd_12in48_test.py
real	0m35.100s
user	0m13.356s
sys	0m7.339s
```

Further improvement are possible too, removing or tightening up `sleep()` calls and changing how the busy pin is polled.  The same changes apply to the 12.48inch e-Paper Module (B), but I don't have one to test against.  Also, an initial call to `clear()` probably isn't needed due to how the entire panel is updated.